### PR TITLE
feat: redesign site with warm editorial theme

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,24 +1,12 @@
 ---
 layout: default
+title: "404"
+permalink: /404.html
 ---
 
-<style type="text/css" media="screen">
-  .container {
-    margin: 10px auto;
-    max-width: 600px;
-    text-align: center;
-  }
-  h1 {
-    margin: 30px 0;
-    font-size: 4em;
-    line-height: 1;
-    letter-spacing: -1px;
-  }
-</style>
-
 <div class="container">
-  <h1>404</h1>
-
-  <p><strong>Page not found :(</strong></p>
-  <p>The requested page could not be found.</p>
+  <div class="page-404">
+    <h1>404</h1>
+    <p>This page doesn't exist. <a href="/">Head home</a>.</p>
+  </div>
 </div>

--- a/_config.yml
+++ b/_config.yml
@@ -15,20 +15,44 @@
 # in the templates via {{ site.myvariable }}.
 title: Vayu Technology
 email: hi@vayu.com.au
-description: >- # this means to ignore newlines until "baseurl:"
-  Write an awesome description for your new site here. You can edit this
-  line in _config.yml. It will appear in your document head meta (for
-  Google search results) and in your feed.xml site description.
+description: >-
+  Vayu Technology builds small, focused software products and writes
+  about the craft of engineering.
+author: Vayu Technology
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://www.vayu.com.au"
 twitter_username: vayutech
 # github_username:  vayu
 
 # Build settings
 markdown: kramdown
-theme: minima
 plugins:
   - jekyll-feed
+  - jekyll-paginate-v2
+  - jekyll-seo-tag
+
+pagination:
+  enabled: true
+  per_page: 5
+  permalink: "/page/:num/"
+  sort_reverse: true
+
+autopages:
+  enabled: true
+  tags:
+    enabled: true
+    layouts:
+      - autopage_tags.html
+    title: "Tagged: :tag"
+    permalink: "/tags/:tag/"
+  categories:
+    enabled: true
+    layouts:
+      - autopage_category.html
+    title: ":cat"
+    permalink: "/category/:cat/"
+  collections:
+    enabled: false
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list

--- a/_layouts/autopage_category.html
+++ b/_layouts/autopage_category.html
@@ -1,15 +1,10 @@
 ---
-title: Blog
 layout: default
-permalink: /blog/
-pagination:
-  enabled: true
 ---
 
 <div class="container">
   <div class="page-header">
-    <h1>Blog</h1>
-    <p>Writing about software, engineering, and the things we're building.</p>
+    <h1>{{ page.title }}</h1>
   </div>
 
   <div class="blog-list">

--- a/_layouts/autopage_tags.html
+++ b/_layouts/autopage_tags.html
@@ -1,15 +1,10 @@
 ---
-title: Blog
 layout: default
-permalink: /blog/
-pagination:
-  enabled: true
 ---
 
 <div class="container">
   <div class="page-header">
-    <h1>Blog</h1>
-    <p>Writing about software, engineering, and the things we're building.</p>
+    <h1>{{ page.title }}</h1>
   </div>
 
   <div class="blog-list">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,124 +1,57 @@
-<!DOCTYPE HTML>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  {% seo %}
+  <link rel="stylesheet" href="/assets/css/style.css">
 
-<html>
-  <head>
-    <title>{{ page.title }}</title>
-
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-    <meta property="og:title" content="{{page.title}}" />
-    <meta property="og:url" content="https://www.vayu.com.au{{page.url}}" />
-    <meta property="og:type" content="website" />
-    <meta property="og:image" content="{{page.cover_image | default: 'https://www.vayu.com.au/assets/images/frontend/mockup/slide1.png'}}" />
-    <meta property="og:description" content= "{{page.title}} - {{page.excerpt}}" />
-    <meta name="twitter:widgets:theme" content="light">
-
-
-    <link rel="stylesheet" type="text/css" href="/assets/css/frontend/bootstrap.min.css" />
-    <link rel="stylesheet" type="text/css" href="/assets/css/frontend/bootstrap-responsive.min.css" />
-    <link rel="stylesheet" type="text/css" href="/assets/css/frontend/styles.css" />
-    <link rel="stylesheet" type="text/css" href="/assets/css/frontend/prettyPhoto.css" />
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css" />
-    
-    <!-- <link rel="shortcut icon" href="/assets/images/frontend/favicon.ico" type="image/x-icon"/> -->
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css" />
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
-
-    <script src="/assets/js/frontend/jquery.backstretch.min.js"></script>
-    <script src="/assets/js/frontend/slides.min.jquery.js"></script>
-    <script src="/assets/js/frontend/jquery.tipTip.minified.js"></script>    
-    <script src="/assets/js/frontend/main2.js"></script>    
-    <script src="/assets/js/frontend/organictabs.jquery.js"></script>
-    <script src="/assets/js/frontend/jquery.prettyPhoto.js"></script>    
-    
-    <script type="text/javascript">
-      $(document).ready(function () {
-      $('.to-top').click(function () {
-      $("html, body").animate({ scrollTop: 0 }, 600);
-      return false;
-      });
-      });
-    </script>
-  </head>
-  <body>
-    <div class="top-nav black">
-      <div class="wrapper">
-
-	<div class="row-fluid" style="text-align: center;">
-	  <div class="span6">
-            <a href="/">
-              <h1>Vayu Technology</h1>
-            </a>
-            <span class="slogan hidden-phone">Software Design & Development Services</span>
-	  </div>
-
-	  <div class="span6">
-            <div class="row-fluid">
-              <ul class="mainmenu visible-desktop">
-		<!-- <li class="span3"><a href="/jobs">WE'RE HIRING</a></li> -->
-		<li class="span2"><a href="/blog">BLOG</a></li>
-		<li class="span2"><a href="/jobs">JOBS</a></li>		
-		<li class="span3"><a href="mailto:hi@vayu.com.au">GET IN TOUCH</a></li>              
-              </ul>
-
-            </div>
-	  </div>
-
-	</div>
-
-      </div>
-    </div>
-
-    <!-- <%= render partial: "shared/header"%> -->
-    
-    {{ content }}
-
-
-    
-    <div class="footer">
-      <div class="wrapper">
-	<div class="row-fluid">
-
-	  <div class="span5 copy">
-            <p>
-	      © {{ site.time | date: '%Y' }} Vayu Technology. All rights reserved
-	      &nbsp;|&nbsp;
-              hi@vayu.com.au
-	    </p>
-	  </div>
-
-	  <div class="span4 visible-desktop">
-            <ul class="bottom-menu ">
-              <!-- <li><a href="#">Get the App</a></li> -->
-              <!-- <li><a href="#">Press Kit</a></li> -->
-              <!-- <li><a href="#">Support</a></li> -->
-              <!-- <li><a href="#">Contact</a></li> -->
-            </ul>
-	  </div>
-
-	  <div class="span3 rightblack visible-desktop">
-            <ul class="bottom-social-menu">
-              <li><a href="https://www.facebook.com/VayuTechnology" class="fb"><span>facebook</span></a></li>
-              <li><a href="http://twitter.com/VayuTech" class="tw"><span>tw</span></a></li>
-            </ul>
-            <a href="#" class="to-top"></a>
-	  </div>
-
-	</div>
-      </div>
-    </div>
-
-    
-    <!-- <%= render partial: "shared/footer" %> -->
-  </body>
   <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-43703831-1', 'vayu.com.au');
-    ga('send', 'pageview');
-    
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init os ds Ie us vs ss ls capture calculateEventProperties register register_once register_for_session unregister unregister_for_session ws getFeatureFlag getFeatureFlagPayload getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty bs ps createPersonProfile setInternalOrTestUser ys es $s opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing cs debug M gs getPageViewId captureTraceFeedback captureTraceMetric Qr".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('phc_vKrqV8whdLR72vqhp3ntWzfxRVfi6R4gaT4xZg8mNnMn', {
+        api_host: 'https://eu.i.posthog.com',
+        defaults: '2026-01-30',
+    })
   </script>
+</head>
+<body>
+  <div class="site-wrapper">
+
+    <nav class="site-nav">
+      <div class="container">
+        <a href="/" class="site-logo">
+          <span class="logo-mark">V</span>
+          <span class="logo-text">
+            <span class="logo-title">Vayu Technology</span>
+            <span class="logo-tagline">Software, products &amp; ideas</span>
+          </span>
+        </a>
+        <button class="nav-toggle" aria-label="Toggle navigation" onclick="document.querySelector('.nav-links').classList.toggle('active')">
+          <span></span><span></span><span></span>
+        </button>
+        <ul class="nav-links">
+          <li><a href="/blog">Blog</a></li>
+          <li><a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#104;&#105;&#64;&#118;&#97;&#121;&#117;&#46;&#99;&#111;&#109;&#46;&#97;&#117;" class="nav-cta">Get in touch</a></li>
+        </ul>
+      </div>
+    </nav>
+
+    <main>
+      {{ content }}
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <div class="footer-inner">
+          <span class="footer-copy">&copy; {{ site.time | date: '%Y' }} Vayu Technology</span>
+          <ul class="footer-links">
+            <li><a href="/about">About</a></li>
+            <li><a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#104;&#105;&#64;&#118;&#97;&#121;&#117;&#46;&#99;&#111;&#109;&#46;&#97;&#117;">&#104;&#105;&#64;&#118;&#97;&#121;&#117;&#46;&#99;&#111;&#109;&#46;&#97;&#117;</a></li>
+          </ul>
+        </div>
+      </div>
+    </footer>
+
+  </div>
+</body>
 </html>

--- a/_layouts/job.html
+++ b/_layouts/job.html
@@ -2,56 +2,21 @@
 layout: default
 ---
 
-
-<div class="content-wrap">
-  <div class="main-features">
-    <div class="wrapper">
-      <div class="row-fluid">
-        <div class="span12" style="padding-bottom: 20px">
-          <h1 style="font-size: 30px;line-height: 1.6;text-align:left;"><a href="{{ page.url }}">{{ page.title }}</a></h1>
-          <div style="padding-bottom: 20px">{{ page.date | date: '%B %d, %Y' }}</div>
-
-          <div class="excerpt" style="font-size: 18px;line-height: 1.6;">
-	    {{ page.excerpt | strip_html | truncatewords:75 }}
-          </div>
-          
-        </div>
-      </div>	  
-    </div>
+<header class="post-header">
+  <div class="content-container">
+    <span class="post-header-meta">{{ page.date | date: '%B %d, %Y' }}</span>
+    <h1>{{ page.title }}</h1>
   </div>
-</div>
+</header>
 
-
-
-
-<div class="content-wrap">
-
-  <div class="main-features">
-    <div class="wrapper">
-      <h1 class="main-feat-title" id="features">
-        We specialise in <span class="bold">bespoke software</span>
-      </h1>
-
-      <h2 class="main-feat-p">We can build the ideas in your head and make them a reality</h2>
-
-      <div class="box first">
-        <div class="row-fluid">
-          <div class="span6">
-            <H4>Building better applications</H4>
-
-            <p>Exceptional development on the web is done with cutting-edge technologies like Ruby, React JS, Vue JS and other modern frameworks. At Vayu, we're polyglots - we use the the latest technology to rapidly bring your projects to fruition.   We also understand how to build at scale with containers & Kubernetes in our toolbelt.</p>
-            <p>We're always discovering and learning.  Naturally curious, we stay on top of trends and new technologies to help our clients reach future-facing solutions.</p>
-          </div>
-
-          <div class="span6 imagelink1 zoomlink ">
-            <a href="/assets/images/frontend/mockup/main1.png" data-gal="prettyPhoto[gallery1]">
-              <span class="roll"></span>
-	      <img src="/assets/images/frontend/mockup/main1.png" rel="prettyPhoto">
-            </a>
-          </div>
-        </div>
-      </div>
-
-    </div>
+<article class="post-body">
+  <div class="content-container">
+    {{ content }}
   </div>
-</div>
+
+  <nav class="post-nav">
+    <div class="content-container">
+      <a href="/jobs">&larr; Back to jobs</a>
+    </div>
+  </nav>
+</article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,57 +2,28 @@
 layout: default
 ---
 
-
-<div class="content-wrap">
-  <div class="main-features">
-    <div class="wrapper">
-      <div class="row-fluid">
-        <div class="span12" style="padding-bottom: 20px">
-          <h1 style="font-size: 30px;line-height: 1.6;text-align:left;"><a href="{{ page.url }}">{{ page.title }}</a></h1>
-          <div style="padding-bottom: 20px">{{ page.date | date: '%B %d, %Y' }}</div>
-
-          <div class="blog" style="font-size: 18px;line-height: 1.6;">
-	    {{ page.content }}
-          </div>
-          
-        </div>
-      </div>	  
+<header class="post-header">
+  <div class="content-container">
+    <span class="post-header-meta">{{ page.date | date: '%B %d, %Y' }} &middot; {{ page.author | default: site.author }}{% if page.categories %} &middot; {{ page.categories | join: ', ' }}{% endif %}</span>
+    <h1>{{ page.title }}</h1>
+    {% if page.tags.size > 0 %}
+    <div class="post-tags">
+      {% for tag in page.tags %}
+      <a href="/tags/{{ tag | slugify }}/" class="post-tag">{{ tag }}</a>
+      {% endfor %}
     </div>
+    {% endif %}
   </div>
-</div>
+</header>
 
+<article class="post-body">
+  <div class="content-container">
+    {{ content }}
+  </div>
 
-
-
-<div class="content-wrap">
-
-  <div class="main-features">
-    <div class="wrapper">
-      <h1 class="main-feat-title" id="features">
-        We specialise in <span class="bold">bespoke software</span>
-      </h1>
-
-      <h2 class="main-feat-p">We can build the ideas in your head and make them a reality</h2>
-
-      <div class="box first">
-        <div class="row-fluid">
-          <div class="span6">
-            <H4>Building better applications</H4>
-
-            <p>Exceptional development on the web is done with cutting-edge technologies like Ruby, React JS, Vue JS and other modern frameworks. At Vayu, we're polyglots - we use the the latest technology to rapidly bring your projects to fruition.   We also understand how to build at scale with containers & Kubernetes in our toolbelt.</p>
-            <p>We're always discovering and learning.  Naturally curious, we stay on top of trends and new technologies to help our clients reach future-facing solutions.</p>
-          </div>
-
-          <div class="span6 imagelink1 zoomlink ">
-            <a href="/assets/images/frontend/mockup/main1.png" data-gal="prettyPhoto[gallery1]">
-              <span class="roll"></span>
-	      <img src="/assets/images/frontend/mockup/main1.png" rel="prettyPhoto">
-            </a>
-          </div>
-        </div>
-      </div>
-
+  <nav class="post-nav">
+    <div class="content-container">
+      <a href="/blog">&larr; Back to blog</a>
     </div>
-
-  </div>
-</div>
+  </nav>
+</article>

--- a/_posts/2015-12-21-vayu-blog-hello-world.markdown
+++ b/_posts/2015-12-21-vayu-blog-hello-world.markdown
@@ -3,6 +3,7 @@ layout: post
 title:  "Vayu Blog - hello world"
 date:   2015-12-21 03:30:30 +0545
 categories: blog
+tags: [vayu, announcements]
 ---
 Hello world.
 

--- a/_posts/2015-12-28-25-lame-excuses-people-give-for-not-becoming-an-entrepreneur-519a02.markdown
+++ b/_posts/2015-12-28-25-lame-excuses-people-give-for-not-becoming-an-entrepreneur-519a02.markdown
@@ -4,6 +4,7 @@ title:  "25 Lame Excuses People Give for Not Becoming an Entrepreneur"
 date:   2015-12-28 05:26:09.742623
 excerpt: "Jayson Demers via Entrepreneur.com wrote a lovely article this year about what holds people back from becoming an entrepreneur. This is a rebuttal from someone who has been banging their head against startups for about 5 years now."
 categories: blog
+tags: [entrepreneurship, startups]
 ---
 
 Jayson Demers via <a href="http://www.entrepreneur.com/article/251998">Entrepreneur.com</a> wrote a lovely article this year about what holds people back from becoming an entrepreneur. This is a rebuttal from someone who has been banging their head against startups for about 5 years now.

--- a/_posts/2015-12-29-the-differences-between-accelerator-and-incubators-1df8c0.markdown
+++ b/_posts/2015-12-29-the-differences-between-accelerator-and-incubators-1df8c0.markdown
@@ -3,6 +3,7 @@ layout: post
 title:  "The differences between accelerator and incubators"
 date:   2015-12-29 10:19:07.905617
 categories: blog
+tags: [startups, accelerators, incubators]
 excerpt: "<p>Accelerators and incubators offer various opportunities for early startups.&nbsp; Deciding whether or not you should pursue business through one depends on how confident you are about running your business.&nbsp;</p>"
 ---
 <p>&ldquo;While incubators help companies stand and walk, accelerators teach companies to run.&rdquo;</p>

--- a/_posts/2015-12-30-accelerators-and-incubators-in-nepal-d4648c.markdown
+++ b/_posts/2015-12-30-accelerators-and-incubators-in-nepal-d4648c.markdown
@@ -4,6 +4,7 @@ title:  "Accelerators and incubators in Nepal"
 date:   "2015-12-30 10:17:34.094874"
 excerpt: "In recent years, new Nepali entrepreneurs have emerged. Although for these entrepreneurs, coming up with new business ideas might be easy; it can be quite difficult for them to develop those ideas into a profitable business.&nbsp; So, in order to nurture and guide these new entrepreneurs, startup accelerators and incubators have also emerged.&nbsp; These companies act as a platform for the new startups and provide them with opportunities allowing them to grow in the global marketplace."
 categories: blog
+tags: [startups, accelerators, nepal]
 ---
 In recent years, new Nepali entrepreneurs have emerged. Although for these entrepreneurs, coming up with new business ideas might be easy; it can be quite difficult for them to develop those ideas into a profitable business.&nbsp; So, in order to nurture and guide these new entrepreneurs, startup accelerators and incubators have also emerged.&nbsp; These companies act as a platform for the new startups and provide them with opportunities allowing them to grow in the global marketplace.
 

--- a/_posts/2015-12-30-rubynepal-december-meetup-a32d38.markdown
+++ b/_posts/2015-12-30-rubynepal-december-meetup-a32d38.markdown
@@ -3,6 +3,7 @@ layout: post
 title:  "RubyNepal December Meetup"
 date:   2015-12-21 08:23:37.990316
 categories: blog
+tags: [ruby, community, nepal]
 ---
 
 RubyNepal organized its final meetup for 2015 on 20<sup>th</sup>&nbsp;December, 2015 at Innovation Hub, FNCCI Building, Teku, which had been on hold for few months due to fuel crisis and all the crazy things going on in Kathmandu since past several months.

--- a/_posts/2016-01-04-some-of-the-notable-seed-accelerators-5bb34e.markdown
+++ b/_posts/2016-01-04-some-of-the-notable-seed-accelerators-5bb34e.markdown
@@ -4,6 +4,7 @@ title:  "Some of the most notable seed accelerators"
 date:   "2016-01-04 10:25:07.279863"
 excerpt: With a community over 1600 founders and an added value of over $30 billion, <a href="http://www.ycombinator.com">Y combinator</a> has become one of the biggest and the most commercially successful startup seed accelerator. Paul Graham, Jessica Livingston, Trevor Blackwell and Robert Morris initially founded it in 2005 and since then it has funded over 800 startups.&nbsp;
 categories: blog
+tags: [startups, accelerators]
 ---
 <p><span style="font-size:20px;"><strong><u>Y combinator</u></strong></span></p>
 

--- a/_posts/2016-01-05-understanding-native-and-hybrid-apps-600e5b.markdown
+++ b/_posts/2016-01-05-understanding-native-and-hybrid-apps-600e5b.markdown
@@ -4,6 +4,7 @@ title:  "Understanding Native and Hybrid apps"
 date:   "2016-01-05 09:59:40.577115"
 excerpt: "Known for its sleek and simple design, iOS uses multi-touch gestures, which is based on the concept of direct manipulation Interface. Its control elements consist of switches, buttons and sliders. Moreover, interaction with the operating system includes gestures such as swipe, tap, and pinch all of which have specific definitions in the context of the iOS and its multi-touch interface."
 categories: blog
+tags: [mobile, ios, android]
 ---
 <h2>Native</h2>
 

--- a/_posts/2017-02-10-what-do-you-want-to-learn-in-2017-4a2fd9.markdown
+++ b/_posts/2017-02-10-what-do-you-want-to-learn-in-2017-4a2fd9.markdown
@@ -3,6 +3,7 @@ layout: post
 title:  "What do you want to learn in 2017"
 date:   "2017-02-10 15:00:14.361307"
 categories: blog
+tags: [team, learning]
 excerpt: "Based on the recent Hacker News post 'Ask HN: What do you want to learn in 2017?' we asked the entire team here at Vayu Technology to have a think about what they wanted to focus on in 2017. Here was what they came up with."
 ---
 <h2>Batsal</h2>

--- a/_posts/2017-03-28-push-notifications-with-web-push-protocol-6f37cc.markdown
+++ b/_posts/2017-03-28-push-notifications-with-web-push-protocol-6f37cc.markdown
@@ -3,6 +3,7 @@ layout: post
 title:  "Push Notifications with Web Push Protocol"
 date:   "2017-03-28 08:49:20.449038"
 categories: blog
+tags: [web, javascript, push-notifications]
 excerpt: "Push notifications are a great way to interact with the users of your application. However, a major roadblock on integrating push notification to your application is the requirement of signing up and setting up push service server for different browsers that support different protocols for pushing notifications from your application to the client&rsquo;s browser."
 ---
 

--- a/_posts/2019-09-04-ruby-on-rails-6.0-released.markdown
+++ b/_posts/2019-09-04-ruby-on-rails-6.0-released.markdown
@@ -3,6 +3,7 @@ layout: post
 title:  "Ruby on Rails 6.0 Released"
 date:   "2019-09-04 08:49:20.449038"
 categories: blog
+tags: [ruby, rails]
 excerpt: "Last month brought the release of Ruby on Rails 6.0.  Looking back on the past 12 months of Ruby / Ruby on Rails development it's clear that DHH was right in saying that 'Ruby isn't dying, it's maturing'"
 cover_image: "https://www.vayu.com.au/assets/images/blog/yay-rails.png"
 ---

--- a/about.md
+++ b/about.md
@@ -1,18 +1,18 @@
 ---
-layout: page
+layout: default
 title: About
 permalink: /about/
 ---
 
-This is the base Jekyll theme. You can find out more info about customizing your Jekyll theme, as well as basic Jekyll usage documentation at [jekyllrb.com](https://jekyllrb.com/)
+<div class="container">
+  <div class="page-header">
+    <h1>About</h1>
+  </div>
 
-You can find the source code for Minima at GitHub:
-[jekyll][jekyll-organization] /
-[minima](https://github.com/jekyll/minima)
-
-You can find the source code for Jekyll at GitHub:
-[jekyll][jekyll-organization] /
-[jekyll](https://github.com/jekyll/jekyll)
-
-
-[jekyll-organization]: https://github.com/jekyll
+  <div class="content-container" style="padding-top: 2rem; padding-bottom: 4rem;">
+    <div class="post-body">
+      <p>Vayu Technology is a software company building small, focused products. We're based in Australia and write about technology, engineering, and the things we learn along the way.</p>
+      <p>Get in touch at <a href="mailto:hi@vayu.com.au">hi@vayu.com.au</a>.</p>
+    </div>
+  </div>
+</div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,781 @@
+/* ============================================
+   VAYU TECHNOLOGY — Site Stylesheet
+   Warm neutral editorial theme
+   ============================================ */
+
+/* --- Fonts --- */
+@import url('https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Outfit:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap');
+
+/* --- Custom Properties --- */
+:root {
+  --color-bg: #f6f1eb;
+  --color-surface: #efe9e1;
+  --color-surface-raised: #e8e0d6;
+  --color-border: #d4cac0;
+  --color-border-subtle: #ddd5cb;
+  --color-text: #2c2824;
+  --color-text-secondary: #6b6259;
+  --color-text-muted: #9a9089;
+  --color-accent: #b45327;
+  --color-accent-dim: rgba(180, 83, 39, 0.1);
+  --color-link: #b45327;
+  --color-link-hover: #8f3f1b;
+  --font-display: 'DM Serif Display', Georgia, serif;
+  --font-body: 'Outfit', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', monospace;
+  --max-width: 1200px;
+  --content-width: 720px;
+  --space-xs: 0.5rem;
+  --space-sm: 1rem;
+  --space-md: 2rem;
+  --space-lg: 4rem;
+  --space-xl: 8rem;
+  --radius: 8px;
+  --transition: 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* --- Reset & Base --- */
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: var(--font-body);
+  font-weight: 300;
+  font-size: 17px;
+  line-height: 1.7;
+  color: var(--color-text);
+  background-color: var(--color-bg);
+  min-height: 100vh;
+}
+
+::selection {
+  background: var(--color-accent);
+  color: #fff;
+}
+
+a {
+  color: var(--color-link);
+  text-decoration: none;
+  transition: color var(--transition);
+}
+
+a:hover {
+  color: var(--color-link-hover);
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+/* --- Noise texture overlay --- */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  opacity: 0.018;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  pointer-events: none;
+  z-index: 9999;
+}
+
+/* --- Layout --- */
+.site-wrapper {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.container {
+  width: 100%;
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 var(--space-md);
+}
+
+.content-container {
+  max-width: var(--content-width);
+  margin: 0 auto;
+  padding: 0 var(--space-md);
+}
+
+/* --- Navigation --- */
+.site-nav {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: rgba(246, 241, 235, 0.88);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.site-nav .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 72px;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  text-decoration: none;
+}
+
+.site-logo:hover {
+  color: var(--color-text);
+}
+
+.site-logo .logo-mark {
+  width: 32px;
+  height: 32px;
+  background: var(--color-accent);
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-size: 1rem;
+  color: #fff;
+  font-weight: 400;
+  font-style: italic;
+  flex-shrink: 0;
+}
+
+.site-logo .logo-text {
+  display: flex;
+  flex-direction: column;
+}
+
+.site-logo .logo-title {
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+  font-weight: 400;
+  color: var(--color-text);
+  line-height: 1.2;
+}
+
+.site-logo .logo-tagline {
+  font-family: var(--font-body);
+  font-size: 0.65rem;
+  font-weight: 400;
+  color: var(--color-text-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  list-style: none;
+}
+
+.nav-links a {
+  color: var(--color-text-secondary);
+  font-size: 0.88rem;
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition: color var(--transition);
+}
+
+.nav-links a:hover {
+  color: var(--color-text);
+}
+
+.nav-links .nav-cta {
+  background: var(--color-accent);
+  color: #fff;
+  padding: 0.5rem 1.2rem;
+  border-radius: 100px;
+  font-weight: 500;
+}
+
+.nav-links .nav-cta:hover {
+  background: var(--color-link-hover);
+  color: #fff;
+}
+
+/* Mobile nav toggle */
+.nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.5rem;
+}
+
+.nav-toggle span {
+  display: block;
+  width: 22px;
+  height: 2px;
+  background: var(--color-text);
+  margin: 5px 0;
+  transition: var(--transition);
+}
+
+/* --- Hero --- */
+.hero {
+  padding: var(--space-lg) 0 var(--space-md);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  top: -200px;
+  right: -200px;
+  width: 600px;
+  height: 600px;
+  background: radial-gradient(circle, var(--color-accent-dim) 0%, transparent 70%);
+  pointer-events: none;
+  animation: drift 20s ease-in-out infinite alternate;
+}
+
+@keyframes drift {
+  0% { transform: translate(0, 0) scale(1); }
+  50% { transform: translate(-100px, 80px) scale(1.1); }
+  100% { transform: translate(50px, -40px) scale(0.95); }
+}
+
+.hero .container {
+  position: relative;
+}
+
+.hero-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--color-accent);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: var(--space-md);
+  opacity: 0;
+  animation: fadeUp 0.8s ease forwards;
+}
+
+.hero-label::before {
+  content: '';
+  width: 24px;
+  height: 1px;
+  background: var(--color-accent);
+}
+
+.hero h1 {
+  font-family: var(--font-display);
+  font-size: clamp(2.8rem, 6vw, 5rem);
+  font-weight: 400;
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+  color: var(--color-text);
+  max-width: 800px;
+  opacity: 0;
+  animation: fadeUp 0.8s ease 0.1s forwards;
+}
+
+.hero h1 em {
+  font-style: italic;
+  color: var(--color-accent);
+}
+
+.hero-description {
+  font-size: 1.15rem;
+  color: var(--color-text-secondary);
+  max-width: 520px;
+  margin-top: var(--space-md);
+  line-height: 1.7;
+  opacity: 0;
+  animation: fadeUp 0.8s ease 0.2s forwards;
+}
+
+@keyframes fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* --- Section Headers --- */
+.section {
+  padding: var(--space-lg) 0;
+}
+
+.section-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: var(--space-lg);
+  padding-bottom: var(--space-sm);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.section-title {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 400;
+  color: var(--color-text);
+}
+
+.section-link {
+  font-size: 0.85rem;
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+/* --- Post Cards (Homepage Grid) --- */
+.posts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: var(--space-md);
+}
+
+.post-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius);
+  padding: var(--space-md);
+  transition: border-color var(--transition), transform var(--transition);
+  display: flex;
+  flex-direction: column;
+}
+
+.post-card:hover {
+  border-color: var(--color-border);
+  transform: translateY(-2px);
+}
+
+.post-card-meta {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  letter-spacing: 0.03em;
+  margin-bottom: var(--space-sm);
+  text-transform: uppercase;
+}
+
+.post-card h3 {
+  font-family: var(--font-display);
+  font-size: 1.3rem;
+  font-weight: 400;
+  line-height: 1.3;
+  margin-bottom: 0.75rem;
+}
+
+.post-card h3 a {
+  color: var(--color-text);
+  transition: color var(--transition);
+}
+
+.post-card h3 a:hover {
+  color: var(--color-accent);
+}
+
+.post-card-excerpt {
+  color: var(--color-text-secondary);
+  font-size: 0.92rem;
+  line-height: 1.65;
+  flex-grow: 1;
+}
+
+.post-card-read {
+  margin-top: var(--space-sm);
+  font-size: 0.82rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.post-card-read::after {
+  content: '\2192';
+  transition: transform var(--transition);
+}
+
+.post-card:hover .post-card-read::after {
+  transform: translateX(4px);
+}
+
+/* --- Blog List Page --- */
+.blog-list {
+  padding: 0;
+}
+
+.blog-list-item {
+  padding: var(--space-md) 0;
+  border-bottom: 1px solid var(--color-border-subtle);
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: var(--space-md);
+  align-items: baseline;
+}
+
+.blog-list-item:first-child {
+  padding-top: 0;
+}
+
+.blog-list-date {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  padding-top: 0.2rem;
+}
+
+.blog-list-content h2 {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 400;
+  line-height: 1.25;
+  margin-bottom: 0.5rem;
+}
+
+.blog-list-content h2 a {
+  color: var(--color-text);
+}
+
+.blog-list-content h2 a:hover {
+  color: var(--color-accent);
+}
+
+.blog-list-content p {
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.65;
+}
+
+/* --- Post/Article Page --- */
+.post-header {
+  padding: var(--space-md) 0 var(--space-sm);
+}
+
+.post-header-meta {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin-bottom: var(--space-sm);
+}
+
+.post-header h1 {
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 400;
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+  max-width: var(--content-width);
+}
+
+.post-body {
+  padding-bottom: var(--space-xl);
+}
+
+.post-body .content-container {
+  font-size: 1.05rem;
+  line-height: 1.8;
+  color: var(--color-text-secondary);
+}
+
+.post-body h1,
+.post-body h2,
+.post-body h3,
+.post-body h4 {
+  font-family: var(--font-display);
+  font-weight: 400;
+  color: var(--color-text);
+  margin-top: var(--space-md);
+  margin-bottom: var(--space-sm);
+}
+
+.post-body h2 { font-size: 1.6rem; }
+.post-body h3 { font-size: 1.3rem; }
+
+.post-body p {
+  margin-bottom: var(--space-sm);
+}
+
+.post-body a {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-color: var(--color-accent-dim);
+}
+
+.post-body a:hover {
+  text-decoration-color: var(--color-accent);
+}
+
+.post-body img {
+  border-radius: var(--radius);
+  margin: var(--space-md) 0;
+}
+
+.post-body ul,
+.post-body ol {
+  margin: 0 0 var(--space-sm) var(--space-md);
+}
+
+.post-body li {
+  margin-bottom: 0.4rem;
+}
+
+.post-body blockquote {
+  border-left: 3px solid var(--color-accent);
+  padding-left: var(--space-md);
+  margin: var(--space-md) 0;
+  color: var(--color-text);
+  font-style: italic;
+}
+
+.post-body code {
+  font-family: var(--font-mono);
+  font-size: 0.88em;
+  background: var(--color-surface-raised);
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+}
+
+.post-body pre {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius);
+  padding: var(--space-sm) var(--space-md);
+  overflow-x: auto;
+  margin: var(--space-md) 0;
+}
+
+.post-body pre code {
+  background: none;
+  padding: 0;
+}
+
+.post-nav {
+  border-top: 1px solid var(--color-border);
+  padding: var(--space-md) 0;
+  margin-top: var(--space-lg);
+}
+
+.post-nav a {
+  font-size: 0.85rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+/* --- Page Title (for blog, jobs, etc.) --- */
+.page-header {
+  padding: var(--space-md) 0 var(--space-sm);
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: var(--space-sm);
+}
+
+.page-header h1 {
+  font-family: var(--font-display);
+  font-size: clamp(2.2rem, 4vw, 3.2rem);
+  font-weight: 400;
+  letter-spacing: -0.02em;
+}
+
+.page-header p {
+  color: var(--color-text-secondary);
+  margin-top: var(--space-xs);
+  font-size: 1.05rem;
+}
+
+/* --- Tags --- */
+.post-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: var(--space-sm);
+}
+
+.post-tag {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.03em;
+  padding: 0.25rem 0.65rem;
+  border: 1px solid var(--color-border);
+  border-radius: 100px;
+  color: var(--color-text-secondary);
+  transition: border-color var(--transition), color var(--transition);
+}
+
+.post-tag:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+/* --- Pagination --- */
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-md);
+  padding: var(--space-md) 0 var(--space-sm);
+}
+
+.pagination a {
+  font-size: 0.85rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.pagination-info {
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+}
+
+/* --- Jobs Page --- */
+.jobs-empty {
+  text-align: center;
+  padding: var(--space-xl) 0;
+  color: var(--color-text-secondary);
+}
+
+.jobs-empty a {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+/* --- 404 --- */
+.page-404 {
+  text-align: center;
+  padding: var(--space-xl) 0;
+}
+
+.page-404 h1 {
+  font-family: var(--font-display);
+  font-size: 8rem;
+  color: var(--color-border);
+  line-height: 1;
+}
+
+.page-404 p {
+  color: var(--color-text-secondary);
+  margin-top: var(--space-sm);
+}
+
+/* --- Footer --- */
+.site-footer {
+  margin-top: auto;
+  border-top: 1px solid var(--color-border-subtle);
+  padding: var(--space-lg) 0;
+}
+
+.footer-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.footer-copy {
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+}
+
+.footer-links {
+  display: flex;
+  gap: var(--space-md);
+  list-style: none;
+}
+
+.footer-links a {
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  transition: color var(--transition);
+}
+
+.footer-links a:hover {
+  color: var(--color-text);
+}
+
+/* --- Responsive --- */
+@media (max-width: 768px) {
+  .hero {
+    padding: var(--space-lg) 0 var(--space-md);
+  }
+
+  .hero::before {
+    width: 300px;
+    height: 300px;
+    top: -100px;
+    right: -100px;
+  }
+
+  .posts-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .blog-list-item {
+    grid-template-columns: 1fr;
+    gap: 0.25rem;
+  }
+
+  .nav-links {
+    display: none;
+    position: absolute;
+    top: 72px;
+    left: 0;
+    right: 0;
+    background: rgba(246, 241, 235, 0.97);
+    backdrop-filter: blur(20px);
+    flex-direction: column;
+    padding: var(--space-md);
+    border-bottom: 1px solid var(--color-border);
+    gap: var(--space-sm);
+  }
+
+  .nav-links.active {
+    display: flex;
+  }
+
+  .nav-toggle {
+    display: block;
+  }
+
+  .footer-inner {
+    flex-direction: column;
+    gap: var(--space-sm);
+    text-align: center;
+  }
+
+  .section-header {
+    flex-direction: column;
+    gap: var(--space-xs);
+  }
+}
+
+@media (max-width: 480px) {
+  .hero h1 {
+    font-size: 2.2rem;
+  }
+
+  .post-card {
+    padding: 1.5rem;
+  }
+}

--- a/assets/images/vayu-logo.svg
+++ b/assets/images/vayu-logo.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 100" fill="currentColor">
+  <!--
+    V Monogram: two overlapping V shapes sharing a bottom vertex.
+    Large V sits left, its right arm is shorter (ends ~25% height).
+    Small V overlaps from upper-right, both arms reach the top.
+    A triangular gap separates them.
+  -->
+
+  <!-- Large V -->
+  <polygon points="0,0 14,0 40,70 54,25 68,25 40,105"/>
+
+  <!-- Small V -->
+  <polygon points="64,0 74,0 54,58 82,0 95,0 40,105"/>
+
+  <!-- Divider -->
+  <line x1="116" y1="12" x2="116" y2="88" stroke="currentColor" stroke-width="1.5" opacity="0.4"/>
+
+  <!-- Wordmark: VAYU in thin geometric uppercase -->
+  <!-- V -->
+  <path d="M140,18 L160,82 L164,82 L184,18 L179,18 L162,74 L145,18 Z"/>
+  <!-- A -->
+  <path d="M196,82 L214,18 L219,18 L237,82 L232,82 L227,66 L206,66 L201,82 Z M208,62 L225,62 L216.5,34 Z"/>
+  <!-- Y -->
+  <path d="M250,18 L265,50 L280,18 L275,18 L265,42 L255,18 Z M263,50 L267,50 L267,82 L263,82 Z"/>
+  <!-- U -->
+  <path d="M296,18 L296,66 Q296,82 310,82 Q324,82 324,66 L324,18 L320,18 L320,65 Q320,78 310,78 Q300,78 300,65 L300,18 Z"/>
+</svg>

--- a/index.md
+++ b/index.md
@@ -1,115 +1,31 @@
 ---
-title: Vayu | Home
+title: Vayu Technology
 layout: default
 ---
 
+<section class="hero">
+  <div class="container">
+    <span class="hero-label">Software &amp; Engineering</span>
+    <h1>We build products<br>and write about <em>the craft</em></h1>
+    <p class="hero-description">Vayu Technology is a software company shipping small, focused products. We share what we learn along the way.</p>
+  </div>
+</section>
 
-<!--### Header - Arrow ###-->
-<div class="main-content-second">
-
-  <div class="wrapper">
-    <h1 class="title"> Vayu is what you need</h1>
-
-    <h2>We specialise in test-driven development, user-centered design <br/>
-      & beautiful functioning code.</h2>
-
-    <div class="slides">
-      <div class="slides_container">
-        <img src="assets/images/frontend/mockup/slide1.png">
-        <img src="assets/images/frontend/mockup/slide2.png">
-        <img src="assets/images/frontend/mockup/slide3.png">	
-      </div>
+<section class="section">
+  <div class="container">
+    <div class="section-header">
+      <h2 class="section-title">Latest from the blog</h2>
+      <a href="/blog" class="section-link">All posts &rarr;</a>
+    </div>
+    <div class="posts-grid">
+      {% for post in site.posts limit:6 %}
+      <article class="post-card">
+        <span class="post-card-meta">{{ post.date | date: '%b %d, %Y' }}</span>
+        <h3><a href="{{ post.url }}">{{ post.title }}</a></h3>
+        <p class="post-card-excerpt">{{ post.excerpt | strip_html | truncatewords: 30 }}</p>
+        <a href="{{ post.url }}" class="post-card-read">Read</a>
+      </article>
+      {% endfor %}
     </div>
   </div>
-
-</div>
-
-
-<div class="content-wrap second">
-  <div class="features">
-    <div class="wrapper">
-      <div class="row-fluid ">
-        <div class="span12">
-          <h1>Why should you choose <span class="bold">Vayu?</span></h1>
-
-          <!-- <h2>Software engineering services</h2> -->
-
-          <div class="row-fluid small ">
-
-            <!--###   Feature 1 ###-->
-            <div class="span4 featu">
-              <div class="featu-box">
-                <div class="icon">
-		  <img src="assets/images/frontend/fut-icon1.png" class="ft1">
-                </div>
-                <h1>Made with love</h1>
-
-                <p>We love software.  Work with us &amp; we'll show you why!  </p>
-              </div>
-            </div>
-
-
-            <!--###   Feature 2 ###-->
-            <div class="span4 featu">
-              <div class="featu-box">
-                <div class="icon">
-		<img src="assets/images/frontend/fut-icon2.png" class="ft1">
-		</div>
-                <h1>Clean design</h1>
-
-                <p>We write beautiful code that would make an engineer blush</p>
-              </div>
-            </div>
-
-            <!--###   Feature 3 ###-->
-            <div class="span4 featu">
-              <div class="featu-box">
-                <div class="icon">
-		  <img src="assets/images/frontend/fut-icon3.png" class="ft1">
-		  </div>
-                <h1>Responsive layouts</h1>
-
-                <p>Built for mobiles from the outset. We live &amp; breathe responsive design.</p>
-              </div>
-            </div>
-          </div>
-
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-<div class="content-wrap">
-
-  <div class="main-features">
-    <div class="wrapper">
-      <h1 class="main-feat-title" id="features">
-        We specialise in <span class="bold">bespoke software</span>
-      </h1>
-
-      <h2 class="main-feat-p">We can build the ideas in your head and make them a reality</h2>
-
-      <div class="box first">
-        <div class="row-fluid">
-          <div class="span6">
-            <H4>Building better applications</H4>
-
-            <p>Exceptional development on the web is done with cutting-edge technologies like Ruby, React JS, Vue JS and other modern frameworks. At Vayu, we're polyglots - we use the the latest technology to rapidly bring your projects to fruition.   We also understand how to build at scale with containers & Kubernetes in our toolbelt.</p>
-            <p>We're always discovering and learning.  Naturally curious, we stay on top of trends and new technologies to help our clients reach future-facing solutions.</p>
-          </div>
-
-          <div class="span6 imagelink1 zoomlink ">
-            <a href="/assets/images/frontend/mockup/main1.png" data-gal="prettyPhoto[gallery1]">
-              <span class="roll"></span>
-	      <img src="assets/images/frontend/mockup/main1.png" rel="prettyPhoto">
-            </a>
-          </div>
-        </div>
-      </div>
-
-    </div>
-
-  </div>
-</div>
+</section>

--- a/jobs.md
+++ b/jobs.md
@@ -1,71 +1,13 @@
 ---
-title: Vayu | Jobs
 layout: default
+title: Jobs
+permalink: /jobs/
+redirect_to: /
 ---
-{%if site.jobs.size == 0%}
-  <div class="content-wrap">
-    <div class="main-features">
-      <div class="wrapper">
-        <div class="row-fluid">
-          <div class="span12">
-	    <p class="text-center">Sorry, there are no current positions listed but you can always apply to <a href="mailto:hi@vayu.com.au">hi@vayu.com.au</a> anytime</p>
-          </div>
-        </div>	  
-      </div>
-    </div>
-  </div>
-{% endif %}
-{% for post in site.jobs %}
-  <div class="content-wrap">
-    <div class="main-features">
-      <div class="wrapper">
-        <div class="row-fluid">
-          <div class="span12">
-            <h2 style="font-size: 30px;line-height: 1.6;text-align:left;"><a href="{{ post.url }}">{{ post.title }}</a></h2>
-            <div style="padding-bottom: 20px">{{ post.date | date: '%B %d, %Y' }}</div>
 
-            <div class="excerpt" style="font-size: 18px;line-height: 1.6;">
-	      {{ post.excerpt | strip_html | truncatewords:75 }}
-            </div>
-           
-          </div>
-        </div>	  
-      </div>
-    </div>
-  </div>
-{% endfor %}
-
-
-
-<div class="content-wrap">
-
-  <div class="main-features">
-    <div class="wrapper">
-      <h1 class="main-feat-title" id="features">
-        We specialise in <span class="bold">bespoke software</span>
-      </h1>
-
-      <h2 class="main-feat-p">We can build the ideas in your head and make them a reality</h2>
-
-      <div class="box first">
-        <div class="row-fluid">
-          <div class="span6">
-            <H4>Building better applications</H4>
-
-            <p>Exceptional development on the web is done with cutting-edge technologies like Ruby, React JS, Vue JS and other modern frameworks. At Vayu, we're polyglots - we use the the latest technology to rapidly bring your projects to fruition.   We also understand how to build at scale with containers & Kubernetes in our toolbelt.</p>
-            <p>We're always discovering and learning.  Naturally curious, we stay on top of trends and new technologies to help our clients reach future-facing solutions.</p>
-          </div>
-
-          <div class="span6 imagelink1 zoomlink ">
-            <a href="/assets/images/frontend/mockup/main1.png" data-gal="prettyPhoto[gallery1]">
-              <span class="roll"></span>
-	      <img src="/assets/images/frontend/mockup/main1.png" rel="prettyPhoto">
-            </a>
-          </div>
-        </div>
-      </div>
-
-    </div>
-
+<script>window.location.href = '/';</script>
+<div class="container">
+  <div class="jobs-empty">
+    <p>This page has moved. <a href="/">Go to the homepage</a>.</p>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Full frontend redesign: modern CSS replacing Bootstrap 2 / jQuery / prettyPhoto / Font Awesome stack
- Warm neutral palette (cream/linen bg, terracotta accent) with DM Serif Display + Outfit typography
- Homepage with hero section and latest blog posts grid
- Blog pagination (5 per page) with tag and category auto-pages at SEO-friendly URLs
- jekyll-seo-tag for canonical URLs, Open Graph, and Twitter Card meta
- PostHog analytics replacing deprecated Google Analytics UA
- Tags added to all existing posts, default author set to Vayu Technology
- Jobs page preserved as redirect to homepage for SEO
- Email addresses entity-encoded against scrapers
- Removed minima theme dependency (eliminates Sass deprecation warnings)

## Test plan
- [x] `bundle exec jekyll build` completes cleanly
- [x] `bundle exec jekyll serve` returns HTTP 200 on all pages
- [x] Blog pagination generates page 1 and page 2
- [x] Tag pages generated at `/tags/{tag}/`
- [x] Category pages generated at `/category/{cat}/`
- [x] `/jobs/` redirects to homepage