### PR TITLE
Blog: From Agency to Product

### DIFF
--- a/_posts/2026-04-03-from-agency-to-product-why-vayu-is-changing-direction.markdown
+++ b/_posts/2026-04-03-from-agency-to-product-why-vayu-is-changing-direction.markdown
@@ -1,0 +1,72 @@
+---
+layout: post
+title: "From Agency to Product: Why Vayu Is Changing Direction"
+date: "2026-04-03 09:00:00 +1000"
+categories: blog
+tags: [vayu, announcements, product, strategy]
+excerpt: "After thirteen years of building software for other people, Vayu is moving away from the agency model to focus entirely on our own products. Here's why, and what we learned along the way."
+---
+
+For over a decade, Vayu Technology has been an agency. We built software for clients; scoped projects, time-and-materials engagements, staff augmentation, the lot. We were good at it. We shipped real things for real businesses and we're proud of that work.
+
+But we're done with it.
+
+Starting now, Vayu is a product company. We're not taking on new client work. Everything we build from here is ours; small, focused products that we own, operate, and stand behind.
+
+This isn't a pivot born out of panic. We've been heading here for a long time.
+
+## The agency trap
+
+The agency model is seductive for engineers who want to start a business. You already have the skills. Clients will pay you to use them. Revenue starts quickly. It feels like entrepreneurship.
+
+And it is, for a while. You learn to sell, to scope, to manage expectations, to ship under pressure.
+
+But the agency model has a ceiling, and we hit it a long time ago.
+
+Here's the pattern: you win a project. You staff it. You deliver. The client is happy. Then either they need more work (and you're locked in) or they don't (and you're scrambling for the next thing). Your best people are always on someone else's roadmap. Your own ideas sit in a backlog that never gets prioritised because there's always a paying client who needs something yesterday.
+
+The economics are brutal too. You sell hours. There are only so many hours. To grow revenue you hire more people, which grows costs at roughly the same rate. Margins stay thin. You're running hard to stay in place.
+
+We've watched this play out over and over; not just at Vayu, but across dozens of agencies we know. The ones that break out almost always do it by building a product on the side that eventually becomes the main thing.
+
+## We've always had one foot in products
+
+If you've been following Vayu since the early days, you know we've never been a pure agency. We had [conx.co](https://conx.co), a takeoff platform for the construction industry that was acquired by Houzz. We had Pasa Trade, an ambitious e-commerce application for the developing world that fell flat. We had side projects and prototypes and "we'll get to it next quarter" ideas stacked up like dirty dishes.
+
+The pattern was always the same: start something promising, get excited, then shelve it because a client engagement needed all hands. The agency always won because the agency always paid the bills.
+
+That tension defined us for years. We talked about being a product company. We put it on our website. But we were still fundamentally selling time.
+
+## What changed
+
+Clients are more sophisticated now. Many can handle their own engineering, or they'd rather buy a product than hire a team to build something custom. There's less room in the middle for agencies like us.
+
+At the same time, a small team with cloud infrastructure and AI-assisted development can now ship what used to take a department. We've seen it firsthand. The gap between "we could build that" and "we shipped that" has never been smaller.
+
+And we got honest with ourselves. We looked at the last thirteen years and asked: what are we actually good at? Not "what do clients pay us for" but "what do we do well when nobody's watching?" And the answer was always building our own stuff. We're better when we own the whole problem. We make sharper decisions when we don't have to justify every trade-off to someone who hasn't read the code.
+
+## What this means in practice
+
+We're not trying to build the next unicorn. If you've met us, you already know that. Cockroach, not unicorn. Small, resilient, hard to kill.
+
+We're building focused tools that solve specific problems well. Not platforms. Not ecosystems. Tools.
+
+We own the full stack; from idea through to production, support, and iteration. No handoffs. No "here's your deliverable, good luck." We don't need 50 people for this. We need a tight team that ships fast and talks to users. The agency world teaches you to spec everything upfront. Products reward the opposite; get something in front of people and learn.
+
+## What the agency years taught us
+
+When someone is paying you by the hour, you don't get to endlessly refactor or chase architectural perfection. You ship on time. Full stop.
+
+Construction has always been our heartland; conx.co came out of years spent deep in that industry, and we've built estimating, takeoff, and project management tools for the sector longer than anything else. But the agency model pulled us across a dozen other domains too: care management software at ShiftCare, marketplace features at Camplify, digital publishing systems for Universal Magazines, industrial media platforms for Westwick-Farrow. Aged care, outdoor hospitality, consumer publishing, B2B trade media - each with its own domain language, regulatory landscape, and definition of "good enough." You learn to spot a bad abstraction from a mile away, and you learn that most problems are the same problem wearing a different hat; but the hat matters more than engineers like to admit.
+
+The agency also forced us to sell. Engineers love to believe that great products sell themselves. They don't. You have to figure out what people actually need (not what they say they need) and explain why they should pay for it. That stuff doesn't go away just because you're building your own thing.
+
+Client deadlines, scope creep, production outages at 2am for software you didn't architect. We know what kind of team we are because we've been through it.
+
+The agency model has one massive advantage: predictable revenue. Someone signs a contract, you do the work, you get paid. Products don't work like that. You build something, put it out there, and hope people care enough to pay for it.
+
+We're walking away from a proven revenue model to bet on ourselves. Honestly, it's mostly terrifying. But the alternative is another thirteen years of selling time, and we've done that.
+
+We'll be writing more about what we're building and what we learn along the way. That's always been the promise of this blog, even when we were too busy with client work to keep it.
+
+If you've worked with us as a client over the years; thank you. Genuinely. You gave us the runway to get here.


### PR DESCRIPTION
## Summary

- New blog post announcing Vayu's shift from agency model to product development
- Covers the reasoning (agency economics, market shift, tooling leverage), Vayu's history with products (conx.co, Pasa Trade), lessons from client work (ShiftCare, Camplify, Universal Magazines, Westwick-Farrow), and the construction industry as our heartland

## Test plan

- [x] Verify post renders correctly on local dev server (`bundle exec jekyll serve`)
- [x] Check post appears on homepage and blog index
- [x] Verify conx.co link works