### PR TITLE
Add CI: Jekyll build and HTML-Proofer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "4.0.1"
+          bundler-cache: true
+
+      - name: Build site
+        run: bundle exec jekyll build
+
+      - name: Install html-proofer
+        run: gem install html-proofer
+
+      - name: Check HTML
+        run: |
+          htmlproofer _site \
+            --ignore-urls "/fonts.googleapis.com/,/fonts.gstatic.com/" \
+            --no-enforce-https \
+            --disable-external


### PR DESCRIPTION
## Summary

- Adds GitHub Actions workflow that runs on pushes to main and PRs
- Builds the Jekyll site (catches broken templates, bad front matter, missing layouts)
- Runs HTML-Proofer on internal links, images, and scripts
- External link checking disabled to avoid flaky CI

## Test plan

- [x] Verified `bundle exec jekyll build` passes locally
- [x] Verified `htmlproofer` passes locally against built site
- [ ] Confirm workflow runs on this PR