### PR TITLE
Add Dependabot for bundler and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary

- Adds Dependabot config for weekly updates to Ruby gems and GitHub Actions

## Test plan

- [ ] Verify Dependabot starts opening PRs after merge